### PR TITLE
Fix listDeals filter params to match FUB API (v1.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.3.3 — 2026-07-03
+
+### Fixed (bug)
+
+- **`listDeals` filter parameters now match the FUB API.** The tool previously exposed `stage`, `assignedUserId`, and `assignedTo` — none of which the FUB `GET /v1/deals` endpoint accepts — so filtering deals by stage or assigned user was silently ignored and returned unfiltered results. Replaced with the real API params: `stageId`, `userId`, `personId`, `includeArchived`, `includeDeleted`, and `status` (`Active` / `Archived`; note that the API's `Deleted` status value does not filter, so `includeDeleted=1` is documented as the way to surface deleted deals). Verified against the live FUB API.
+
+  Thanks to **Tony Greising-Murschel** ([@tony-dot-sh](https://github.com/tony-dot-sh)) for finding and fixing this.
+
+### Compatibility
+
+Backward compatible at the transport level. Any caller that was passing the old `stage` / `assignedUserId` / `assignedTo` params (which never worked) should switch to `stageId` / `userId`.
+
 ## v1.3.2 — 2026-06-06
 
 ### Fixed (bug)

--- a/index.js
+++ b/index.js
@@ -2312,7 +2312,7 @@ export async function handleToolCall(name, rawArgs) {
     case 'about': {
       return {
         server: 'Follow Up Boss MCP Server',
-        version: '1.3.2',
+        version: '1.3.3',
         author: {
           name: 'Ed Neuhaus',
           title: 'Broker / Owner',
@@ -3327,7 +3327,7 @@ export async function startHttp(opts = {}) {
   app.get('/health', (_req, res) => {
     res.json({
       status: 'ok',
-      version: '1.3.2',
+      version: '1.3.3',
       tools: activeTools.length,
       safeMode: FUB_SAFE_MODE,
       authMode: AUTH_DISABLED ? 'none' : (OAUTH_ENABLED ? 'oauth2.1' : 'bearer'),

--- a/index.js
+++ b/index.js
@@ -1674,9 +1674,12 @@ export const TOOL_DEFINITIONS = [
       "fields": { "type": "string", "description": "Comma-separated list of fields to return" },
       "id": { "type": "string", "description": "Comma-separated deal IDs" },
       "pipelineId": { "type": "number", "description": "Filter by pipeline" },
-      "stage": { "type": "string", "description": "Filter by stage" },
-      "assignedUserId": { "type": "number", "description": "Filter by assigned user" },
-      "assignedTo": { "type": "string", "description": "Filter by assigned name" }
+      "stageId": { "type": "number", "description": "Filter by stage (numeric stage ID)" },
+      "personId": { "type": "number", "description": "Return deals linked to a specific person" },
+      "userId": { "type": "number", "description": "Return deals assigned to a specific user" },
+      "includeArchived": { "type": "integer", "enum": [0, 1], "description": "Set to 1 to include deals with status Archived (default 0)" },
+      "includeDeleted": { "type": "integer", "enum": [0, 1], "description": "Set to 1 to include deals with status Deleted (default 0)" },
+      "status": { "type": "string", "enum": ["Active", "Archived"], "description": "Only return deals with this status. For deleted deals use includeDeleted=1 (the API's \"Deleted\" value does not filter — it returns all statuses)." }
     },
     "required": []
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "followupboss-mcp-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A Model Context Protocol (MCP) server for Follow Up Boss CRM by Ed Neuhaus (Neuhaus Realty Group, Austin TX) - 160 tools covering 100% of the official API plus about/help meta tools",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## What

`listDeals` exposed filter params the FUB `GET /v1/deals` endpoint doesn't accept (`stage`, `assignedUserId`, `assignedTo`), so filtering deals by stage or assigned user was silently ignored and returned unfiltered results.

Swaps in the real API params: `stageId`, `userId`, `personId`, `includeArchived`, `includeDeleted`, `status`. Verified against the live FUB API.

## Credit

Fix by **Tony Greising-Murschel** ([@tony-dot-sh](https://github.com/tony-dot-sh)) — his commit `2c75063`, cherry-picked here with authorship preserved. Thanks Tony!

## Changes
- `index.js` — `listDeals` schema params corrected + serverInfo version bump
- `CHANGELOG.md` — v1.3.3 entry
- `package.json` — 1.3.2 → 1.3.3

Backward compatible at the transport level (old params never worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)