### PR TITLE
Fix `npm test` reporting a pass when the API key is invalid

### DIFF
--- a/test.js
+++ b/test.js
@@ -85,14 +85,20 @@ async function run() {
     const content = result.content?.[0]?.text;
     if (content) {
       const data = JSON.parse(content);
-      // FUB identity can return nested or flat -- just verify we got real data back
-      const flat = data.userId || data.id || data.email || data.accountId;
-      const nested = data.identity?.userId || data.identity?.email;
-      const label = data.email || data.identity?.email || data.name || data.identity?.name || 'ok';
-      if (flat || nested || Object.keys(data).length > 0) {
-        ok(`Read-only API call works (account: ${label})`);
+      // An error payload is still a non-empty object, so check for it explicitly
+      // before looking at the identity fields.
+      if (result.isError || data.error || data.status >= 400) {
+        fail('Read-only API call', data.error || `HTTP ${data.status}`);
       } else {
-        fail('Read-only API call', 'Empty response');
+        // FUB identity can return nested or flat -- require a real identifying field
+        const flat = data.userId || data.id || data.email || data.accountId;
+        const nested = data.identity?.userId || data.identity?.email;
+        const label = data.email || data.identity?.email || data.name || data.identity?.name || 'ok';
+        if (flat || nested) {
+          ok(`Read-only API call works (account: ${label})`);
+        } else {
+          fail('Read-only API call', `No identity fields in response: ${JSON.stringify(data).slice(0, 120)}`);
+        }
       }
     } else {
       fail('Read-only API call', 'No content returned');


### PR DESCRIPTION
### What

The read-only API check in `test.js` passes even when Follow Up Boss rejects the
credentials. Running the suite with a deliberately fake key:

```
$ FUB_API_KEY=fake_key_for_smoke_test npm test

  PASS  Server starts and MCP handshake succeeds
  PASS  Lists 160 tools
  PASS  Read-only API call works (account: ok)

3 passed, 0 failed
```

The `getIdentity` call had actually returned:

```json
{
  "error": "Invalid API Key or authentication credentials. ...",
  "status": 401,
  "details": { "errorMessage": "..." }
}
```

### Why it happens

The assertion is:

```js
if (flat || nested || Object.keys(data).length > 0) {
  ok(`Read-only API call works (account: ${label})`);
}
```

`Object.keys(data).length > 0` is true for the error payload — it has three keys.
The `||` chain means the real checks (`flat`, `nested`) never have to hold. So the
only test that touches the network cannot distinguish a working install from a
completely unauthenticated one, which is the failure it exists to catch.

The `label` fallback to `'ok'` then prints `(account: ok)`, which reads like a
successful identity lookup.

### The fix

Check for an error payload before looking at the identity fields, and require a
real identifying field rather than merely a non-empty object.

After the change, the same fake-key run correctly fails:

```
  PASS  Server starts and MCP handshake succeeds
  PASS  Lists 160 tools
  FAIL  Read-only API call: Invalid API Key or authentication credentials. ...

2 passed, 1 failed
```

and exits non-zero.

### Notes

- `test.js` only. No change to `index.js`, no new dependencies, no build step.
- A valid key still passes exactly as before — the `flat` / `nested` field checks
  are unchanged, they are just no longer short-circuited by the length check.
- Syntax checked with `node -c`; `tests/import-overlay.mjs` still 9/9.
- Contribution licensed under ELv2, same as the repo.
